### PR TITLE
Target form action instead of id

### DIFF
--- a/spec/features/ingredients/creating_ingredients_spec.rb
+++ b/spec/features/ingredients/creating_ingredients_spec.rb
@@ -8,7 +8,7 @@ describe "creating ingredients" do
 
     # Is there a form with the given HTML ID?
     it "should have a form to create the ingredients" do
-      expect(page).to have_css("form#new_ingredient")
+      expect(page).to have_css("form[action='#{ingredients_path}']")
     end
 
     # After submitting the form out with the given name, does the

--- a/spec/features/ingredients/editing_ingredients_spec.rb
+++ b/spec/features/ingredients/editing_ingredients_spec.rb
@@ -10,7 +10,7 @@ describe "editing ingredients" do
     # Is there a form with the given id? (check out how it's
     # interpolated below)
     it "should have a form to edit the ingredient" do
-      expect(page).to have_css("form#edit_ingredient_#{@ingredient.id}")
+      expect(page).to have_css("form[action='#{ingredient_path(@ingredient)}']")
     end
 
     # Does the ingredient name get updated when the form is submitted?

--- a/spec/features/recipes/creating_recipes_spec.rb
+++ b/spec/features/recipes/creating_recipes_spec.rb
@@ -7,7 +7,7 @@ describe "creating recipes" do
     it "should have a form to create the recipes" do
       visit new_recipe_path
 
-      expect(page).to have_css("form#new_recipe")
+      expect(page).to have_css("form[action='#{recipes_path}']")
     end
 
     # Does the recipe get created when the form is submitted?

--- a/spec/features/recipes/editing_recipes_spec.rb
+++ b/spec/features/recipes/editing_recipes_spec.rb
@@ -9,7 +9,7 @@ describe "editing recipes" do
 
     # Is there a form with the given HTML id?
     it "should have a form to edit the recipe" do
-      expect(page).to have_css("form#edit_recipe_#{@recipe.id}")
+      expect(page).to have_css("form[action='#{recipe_path(@recipe)}']")
     end
 
     # Does the form correctly update the recipe name?


### PR DESCRIPTION
This pull request updates several feature specs to check for form elements using their `action` attribute instead of their `id`. `form_with` does not create an id by default like `form_for` did at the time these tests were written.

Test improvements for form detection:

* Updated ingredient creation spec to check for a form with `action='#{ingredients_path}'` instead of `id='new_ingredient'`.
* Updated ingredient editing spec to check for a form with `action='#{ingredient_path(@ingredient)}'` instead of `id='edit_ingredient_#{@ingredient.id}'`.
* Updated recipe creation spec to check for a form with `action='#{recipes_path}'` instead of `id='new_recipe'`.
* Updated recipe editing spec to check for a form with `action='#{recipe_path(@recipe)}'` instead of `id='edit_recipe_#{@recipe.id}'`.